### PR TITLE
Exclude default-env.json from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 # auto generated wildcard
 db/.env
 node_modules
+
+mta_archives/
+default-*.json
+
+# dotenv environment variables file
+.env


### PR DESCRIPTION
I noticed that you had a default-env.json committed to your repo and it contains credentials to your HANA DB instance. It's just trial, but still you might want to be cautious here.  Generally, you'd want to add the default-env.json to your .gitignore. That way you can test locally with it but no credentials accidentally get stored into Git. The other thing you can consider now is hybrid testing and the cds bind command if you are using CAP. With this option no credentials are stored in the local file system. https://cap.cloud.sap/docs/advanced/hybrid-testing